### PR TITLE
Better auto port

### DIFF
--- a/src/main/groovy/com/rackspace/deproxy/Endpoint.groovy
+++ b/src/main/groovy/com/rackspace/deproxy/Endpoint.groovy
@@ -46,9 +46,6 @@ class Endpoint {
         if (connectorFactory) {
             this.serverConnector = connectorFactory(this);
         } else {
-            if (port == null) {
-                port = PortFinder.Singleton.getNextOpenPort()
-            }
             this.serverConnector = new SocketServerConnector(this, port)
         }
     }

--- a/src/main/groovy/com/rackspace/deproxy/LocalSocketPair.groovy
+++ b/src/main/groovy/com/rackspace/deproxy/LocalSocketPair.groovy
@@ -6,18 +6,12 @@ class LocalSocketPair {
     public static List<Socket> createLocalSocketPair(port=null) {
 
         if (port == null || port instanceof PortFinder) {
-            PortFinder pf
-            if (port == null) {
-                pf = PortFinder.Singleton
-            } else {
-                pf = port as PortFinder
-            }
-
-            port = pf.getNextOpenPort()
+            port = 0
         }
 
         // create the listener socket
         def listener = new ServerSocket(port)
+        def localPort = listener.getLocalPort()
         def server
 
         // start listening on a separate thread
@@ -26,7 +20,7 @@ class LocalSocketPair {
         }
 
         // create the client socket and connect
-        def client = new Socket("localhost", port)
+        def client = new Socket("localhost", localPort)
 
         t.join()
 

--- a/src/main/groovy/com/rackspace/deproxy/PortFinder.groovy
+++ b/src/main/groovy/com/rackspace/deproxy/PortFinder.groovy
@@ -4,6 +4,7 @@ package com.rackspace.deproxy;
 import groovy.util.logging.Log4j;
 
 
+@Deprecated
 @Log4j
 public class PortFinder {
 

--- a/src/main/groovy/com/rackspace/deproxy/ServerConnector.groovy
+++ b/src/main/groovy/com/rackspace/deproxy/ServerConnector.groovy
@@ -2,6 +2,8 @@ package com.rackspace.deproxy
 
 public interface ServerConnector {
 
+    int port();
+
     void shutdown();
 
 }

--- a/src/main/groovy/com/rackspace/deproxy/ServletServerConnector.groovy
+++ b/src/main/groovy/com/rackspace/deproxy/ServletServerConnector.groovy
@@ -26,6 +26,10 @@ class ServletServerConnector extends HttpServlet implements ServerConnector {
 
     }
 
+    int port() {
+        throw new UnsupportedOperationException("Servlet Server connector doesn't support a port!")
+    }
+
     @Override
     protected void service(HttpServletRequest request,
                            HttpServletResponse response) throws ServletException, IOException {

--- a/src/main/groovy/com/rackspace/deproxy/SocketServerConnector.groovy
+++ b/src/main/groovy/com/rackspace/deproxy/SocketServerConnector.groovy
@@ -10,14 +10,19 @@ class SocketServerConnector implements ServerConnector {
     Endpoint endpoint
     int port
 
-    public SocketServerConnector(Endpoint endpoint, int port) {
+    public SocketServerConnector(Endpoint endpoint, Integer port) {
 
         if (!endpoint) { throw new IllegalArgumentException("endpoint") }
 
         this.endpoint = endpoint
-        this.port = port
 
-        serverSocket = new ServerSocket(port)
+        if(port == null) {
+            serverSocket = new ServerSocket(0)
+            this.port = serverSocket.getLocalPort()
+        } else {
+            serverSocket = new ServerSocket(port)
+            this.port = port
+        }
 
         serverThread = new ListenerThread(this, serverSocket, "Thread-${endpoint.name}");
         serverThread.start();

--- a/src/main/groovy/com/rackspace/deproxy/SocketServerConnector.groovy
+++ b/src/main/groovy/com/rackspace/deproxy/SocketServerConnector.groovy
@@ -22,11 +22,10 @@ class SocketServerConnector implements ServerConnector {
 
         if(port == null) {
             serverSocket = new ServerSocket(0)
-            this.port = serverSocket.getLocalPort()
         } else {
             serverSocket = new ServerSocket(port)
-            this.port = port
         }
+        this.port = serverSocket.getLocalPort()
 
         serverThread = new ListenerThread(this, serverSocket, "Thread-${endpoint.name}");
         serverThread.start();

--- a/src/main/groovy/com/rackspace/deproxy/SocketServerConnector.groovy
+++ b/src/main/groovy/com/rackspace/deproxy/SocketServerConnector.groovy
@@ -10,6 +10,10 @@ class SocketServerConnector implements ServerConnector {
     Endpoint endpoint
     int port
 
+    int port() {
+        port
+    }
+
     public SocketServerConnector(Endpoint endpoint, Integer port) {
 
         if (!endpoint) { throw new IllegalArgumentException("endpoint") }

--- a/src/test/groovy/com/rackspace/deproxy/EndpointPortVsConnectorTest.groovy
+++ b/src/test/groovy/com/rackspace/deproxy/EndpointPortVsConnectorTest.groovy
@@ -65,9 +65,10 @@ class EndpointPortVsConnectorTest extends Specification {
         then:
         endpoint.serverConnector instanceof SocketServerConnector
         SocketServerConnector ssc = (SocketServerConnector)(endpoint.serverConnector)
-        // this next assertion is possibly flaky if PortFinder.Singleton.getNextOpenPort()
-        // gets called somewhere else between "new Endpoint(deproxy)" and here
-        ssc.port == PortFinder.Singleton.currentPort - 1
+
+        //Just need to verify that it didn't throw any exceptions and that the port is not null
+        ssc.port != null
+        ssc.port != 0
         ssc.endpoint == endpoint
     }
 
@@ -126,9 +127,9 @@ class EndpointPortVsConnectorTest extends Specification {
         then:
         endpoint.serverConnector instanceof SocketServerConnector
         SocketServerConnector ssc = (SocketServerConnector)(endpoint.serverConnector)
-        // this next assertion is possibly flaky if PortFinder.Singleton.getNextOpenPort()
-        // gets called somewhere else between "new Endpoint(deproxy)" and here
-        ssc.port == PortFinder.Singleton.currentPort - 1
+
+        ssc.port != null
+        ssc.port != 0
         ssc.endpoint == endpoint
     }
 

--- a/src/test/groovy/com/rackspace/deproxy/EndpointPortVsConnectorTest.groovy
+++ b/src/test/groovy/com/rackspace/deproxy/EndpointPortVsConnectorTest.groovy
@@ -66,7 +66,7 @@ class EndpointPortVsConnectorTest extends Specification {
         endpoint.serverConnector instanceof SocketServerConnector
         SocketServerConnector ssc = (SocketServerConnector)(endpoint.serverConnector)
 
-        //Just need to verify that it didn't throw any exceptions and that the port is not null
+        notThrown(Exception)
         ssc.port != null
         ssc.port != 0
         ssc.endpoint == endpoint

--- a/src/test/groovy/com/rackspace/deproxy/LocalSocketPairTest.groovy
+++ b/src/test/groovy/com/rackspace/deproxy/LocalSocketPairTest.groovy
@@ -83,10 +83,8 @@ class LocalSocketPairTest {
 
         def (Socket client, Socket server) = LocalSocketPair.createLocalSocketPair(pf)
 
-        assertEquals(pf.currentPort - 1, client.port)
-        assertEquals(pf.currentPort - 1, server.localPort)
-
-
+        //Since the port finder is deprecated, and unreliable, this still uses the built in java socket stuff.
+        //The acceptance of a PortFinder just ensures that use of it doesn't break just yet.
 
         PrintWriter writer = new PrintWriter(client.outputStream)
         UnbufferedStreamReader reader = new UnbufferedStreamReader(server.inputStream)


### PR DESCRIPTION
Resolves #63 and probably #52 

This sets up everywhere within Deproxy that was using the PortFinder to find ports to use the `java.net.ServerSocket` port finding logic. The port can then be introspected off the connector trivially. This is likely far more reliable than the PortFinder logic, especially when there's multiple JVM runs (as in parallel testing) and certainly in multi-threaded environments.