### PR TITLE
Separate client connectors

### DIFF
--- a/TODO
+++ b/TODO
@@ -9,6 +9,12 @@ content coding (esp. compression)
         content-encoded message body (e.g. compressed)
         transfer-encoded message body (bytes on the wire)
 
+replace RequestParams with proper object orientation in client connectors
+    ChunkedTransferEncodingClientConnector
+        will require "clarified object model" above
+        this is a modification of the request, and doesn't directly concern the connection - should this be something other than a ClientConnector?
+            not necessarily; that describes DefaultClientConnector as well
+
 Publish releases to maven central
     change package names and group id to 'com.rackspace'
 
@@ -90,11 +96,6 @@ standard headers
 
 gradle?
 
-replace RequestParams with proper object orientation in client connectors
-    ChunkedTransferEncodingClientConnector
-        will require "distinction between message body and transfer-encoded message body" below
-        this is a modification of the request, and doesn't directly concern the connection - should this be something other than a ClientConnector
-            not necessarily; that describes DefaultClientConnector as well
 
 
 better logging

--- a/TODO
+++ b/TODO
@@ -91,7 +91,6 @@ standard headers
 gradle?
 
 replace RequestParams with proper object orientation in client connectors
-    DefaultClientConnector should have a nextConnector constructor parameters, instead of extending BareClientConnector
     ChunkedTransferEncodingClientConnector
         will require "distinction between message body and transfer-encoded message body" below
         this is a modification of the request, and doesn't directly concern the connection - should this be something other than a ClientConnector

--- a/src/main/groovy/com/rackspace/deproxy/DefaultClientConnector.groovy
+++ b/src/main/groovy/com/rackspace/deproxy/DefaultClientConnector.groovy
@@ -1,14 +1,18 @@
 package com.rackspace.deproxy
 
 
-class DefaultClientConnector extends BareClientConnector {
+class DefaultClientConnector implements ClientConnector {
 
-    public DefaultClientConnector() {
-        this(null)
+    public DefaultClientConnector(ClientConnector nextConnector=null) {
+
+        if (nextConnector == null) {
+            nextConnector = new BareClientConnector()
+        }
+
+        this.nextConnector = nextConnector
     }
-    public DefaultClientConnector(Socket socket) {
-        super(socket)
-    }
+
+    ClientConnector nextConnector
 
     @Override
     Response sendRequest(Request request, boolean https, host, port, RequestParams params) {
@@ -68,6 +72,6 @@ class DefaultClientConnector extends BareClientConnector {
             }
         }
 
-        return super.sendRequest(request, https, host, port, params)
+        return nextConnector.sendRequest(request, https, host, port, params)
     }
 }

--- a/src/main/groovy/com/rackspace/deproxy/DefaultClientConnector.groovy
+++ b/src/main/groovy/com/rackspace/deproxy/DefaultClientConnector.groovy
@@ -17,59 +17,56 @@ class DefaultClientConnector implements ClientConnector {
     @Override
     Response sendRequest(Request request, boolean https, host, port, RequestParams params) {
 
-        if (params.sendDefaultRequestHeaders) {
+        if (request.body) {
 
-            if (request.body) {
+            if (params.usedChunkedTransferEncoding) {
 
-                if (params.usedChunkedTransferEncoding) {
+                if (!request.headers.contains("Transfer-Encoding")) {
+                    request.headers.add("Transfer-Encoding", "chunked")
+                }
 
-                    if (!request.headers.contains("Transfer-Encoding")) {
-                        request.headers.add("Transfer-Encoding", "chunked")
+            } else if (!request.headers.contains("Transfer-Encoding") ||
+                        request.headers["Transfer-Encoding"] == "identity") {
+
+                def length
+                String contentType
+                if (request.body instanceof String) {
+                    length = request.body.getBytes("US-ASCII").length
+                    contentType = "text/plain"
+                } else if (request.body instanceof byte[]) {
+                    length = request.body.length
+                    contentType = "application/octet-stream"
+                } else {
+                    throw new UnsupportedOperationException("Unknown data type in requestBody")
+                }
+
+                if (length > 0) {
+                    if (!request.headers.contains("Content-Length")) {
+                        request.headers.add("Content-Length", length)
                     }
-
-                } else if (!request.headers.contains("Transfer-Encoding") ||
-                            request.headers["Transfer-Encoding"] == "identity") {
-
-                    def length
-                    String contentType
-                    if (request.body instanceof String) {
-                        length = request.body.getBytes("US-ASCII").length
-                        contentType = "text/plain"
-                    } else if (request.body instanceof byte[]) {
-                        length = request.body.length
-                        contentType = "application/octet-stream"
-                    } else {
-                        throw new UnsupportedOperationException("Unknown data type in requestBody")
-                    }
-
-                    if (length > 0) {
-                        if (!request.headers.contains("Content-Length")) {
-                            request.headers.add("Content-Length", length)
-                        }
-                        if (!request.headers.contains("Content-Type")) {
-                            request.headers.add("Content-Type", contentType)
-                        }
+                    if (!request.headers.contains("Content-Type")) {
+                        request.headers.add("Content-Type", contentType)
                     }
                 }
             }
+        }
 
-            if (!request.headers.contains("Host")) {
-                def port2 = port
-                if ((port == 80 && !https) ||
-                        (port == 443 && https)){
-                    port2 = null
-                }
-                request.headers.add("Host", HostHeader.CreateHostHeaderValueNoCheck(host, port2))
+        if (!request.headers.contains("Host")) {
+            def port2 = port
+            if ((port == 80 && !https) ||
+                    (port == 443 && https)){
+                port2 = null
             }
-            if (!request.headers.contains("Accept")){
-                request.headers.add("Accept", "*/*")
-            }
-            if (!request.headers.contains("Accept-Encoding")){
-                request.headers.add("Accept-Encoding", "identity, gzip, compress, deflate, *;q=0")
-            }
-            if (!request.headers.contains("User-Agent")){
-                request.headers.add("User-Agent", Deproxy.VERSION_STRING)
-            }
+            request.headers.add("Host", HostHeader.CreateHostHeaderValueNoCheck(host, port2))
+        }
+        if (!request.headers.contains("Accept")){
+            request.headers.add("Accept", "*/*")
+        }
+        if (!request.headers.contains("Accept-Encoding")){
+            request.headers.add("Accept-Encoding", "identity, gzip, compress, deflate, *;q=0")
+        }
+        if (!request.headers.contains("User-Agent")){
+            request.headers.add("User-Agent", Deproxy.VERSION_STRING)
         }
 
         return nextConnector.sendRequest(request, https, host, port, params)

--- a/src/main/groovy/com/rackspace/deproxy/Deproxy.groovy
+++ b/src/main/groovy/com/rackspace/deproxy/Deproxy.groovy
@@ -47,18 +47,18 @@ class Deproxy {
 
     public MessageChain makeRequest(Map params) {
         return makeRequest(
-                params?.url,
-                params?.host ?: "",
+                params?.url as String,
+                (params?.host ?: "") as String,
                 params?.port,
-                params?.method ?: "GET",
-                params?.path ?: "",
+                (params?.method ?: "GET") as String,
+                (params?.path ?: "") as String,
                 params?.headers,
                 params?.requestBody ?: "",
                 params?.defaultHandler,
-                params?.handlers,
-                (params?.addDefaultHeaders == null ? true : params?.addDefaultHeaders),
-                (params?.chunked ? true : false),
-                params?.clientConnector ?: null
+                params?.handlers as Map,
+                (params?.addDefaultHeaders == null ? true : params?.addDefaultHeaders) as boolean,
+                (params?.chunked ? true : false) as boolean,
+                (params?.clientConnector ?: null) as ClientConnector
         );
     }
 

--- a/src/main/groovy/com/rackspace/deproxy/Deproxy.groovy
+++ b/src/main/groovy/com/rackspace/deproxy/Deproxy.groovy
@@ -15,7 +15,8 @@ class Deproxy {
     public static final String VERSION_STRING = String.format("deproxy %s", VERSION);
 
     public def defaultHandler = null
-    public def defaultClientConnector
+    public DefaultClientConnector defaultClientConnector
+    public BareClientConnector bareClientConnector
 
     protected final def messageChainsLock = new ReentrantLock()
     protected Map<String, MessageChain> messageChains = [:]
@@ -35,14 +36,11 @@ class Deproxy {
         return new String(bytes as byte[], "UTF-8")
     }
 
-    Deproxy(defaultHandler=null, ClientConnector defaultClientConnector=null) {
+    Deproxy(defaultHandler=null) {
 
-        if (defaultClientConnector == null) {
-            defaultClientConnector = new DefaultClientConnector()
-        }
-
-        this.defaultHandler = defaultHandler;
-        this.defaultClientConnector = defaultClientConnector
+        this.defaultHandler = defaultHandler
+        this.bareClientConnector = new BareClientConnector()
+        this.defaultClientConnector = new DefaultClientConnector(this.bareClientConnector)
     }
 
     public MessageChain makeRequest(Map params) {
@@ -87,7 +85,11 @@ class Deproxy {
         headers = new HeaderCollection(headers)
 
         if (!clientConnector) {
-            clientConnector = this.defaultClientConnector;
+            if (addDefaultHeaders) {
+                clientConnector = this.defaultClientConnector
+            } else {
+                clientConnector = this.bareClientConnector
+            }
         }
 
         def requestId = UUID.randomUUID().toString()
@@ -130,7 +132,6 @@ class Deproxy {
 
         RequestParams requestParams = new RequestParams()
         requestParams.usedChunkedTransferEncoding = chunked;
-        requestParams.sendDefaultRequestHeaders = addDefaultHeaders;
 
         log.debug "calling sendRequest"
         Response response = clientConnector.sendRequest(request, https, host, port, requestParams)

--- a/src/main/groovy/com/rackspace/deproxy/RequestParams.groovy
+++ b/src/main/groovy/com/rackspace/deproxy/RequestParams.groovy
@@ -3,5 +3,4 @@ package com.rackspace.deproxy
 
 class RequestParams {
     boolean usedChunkedTransferEncoding = false;
-    boolean sendDefaultRequestHeaders = true;
 }

--- a/src/test/groovy/com/rackspace/deproxy/BareClientConnectorTest.groovy
+++ b/src/test/groovy/com/rackspace/deproxy/BareClientConnectorTest.groovy
@@ -55,7 +55,6 @@ class BareClientConnectorTest {
         BareClientConnector clientConnector = new BareClientConnector(client)
         Request request = new Request("GET", "/", ['Content-Length': '0'])
         RequestParams params = new RequestParams()
-        params.sendDefaultRequestHeaders = false
 
         Response response = clientConnector.sendRequest(request, false, "localhost", server.port, params)
 

--- a/src/test/groovy/com/rackspace/deproxy/ChunkedBodiesTest.groovy
+++ b/src/test/groovy/com/rackspace/deproxy/ChunkedBodiesTest.groovy
@@ -113,7 +113,9 @@ This is the next paragraph.
         RequestParams params = new RequestParams()
         params.usedChunkedTransferEncoding = true
 
-        DefaultClientConnector clientConnector = new DefaultClientConnector(client)
+        DefaultClientConnector clientConnector =
+                new DefaultClientConnector(
+                        new BareClientConnector(client))
 
         Response response = clientConnector.sendRequest(request, false,
                 "localhost", server.localPort, params)
@@ -265,7 +267,9 @@ This is the next paragraph.
         Request request = new Request("GET", "/",
                 ["Transfer-Encoding": "chunked"], body)
 
-        DefaultClientConnector clientConnector = new DefaultClientConnector(client)
+        DefaultClientConnector clientConnector =
+                new DefaultClientConnector(
+                        new BareClientConnector(client))
 
 
 

--- a/src/test/groovy/com/rackspace/deproxy/ConnectionReuseTest.groovy
+++ b/src/test/groovy/com/rackspace/deproxy/ConnectionReuseTest.groovy
@@ -25,7 +25,7 @@ class ConnectionReuseTest {
         def endpoint = this.deproxy.addEndpoint(this.port);
 
         def socket = (endpoint.serverConnector as SocketServerConnector).createRawConnection()
-        client = new DefaultClientConnector(socket)
+        client = new DefaultClientConnector(new BareClientConnector(socket))
 
     }
 

--- a/src/test/groovy/com/rackspace/deproxy/ConnectionReuseTest.groovy
+++ b/src/test/groovy/com/rackspace/deproxy/ConnectionReuseTest.groovy
@@ -12,7 +12,7 @@ class ConnectionReuseTest {
     Deproxy deproxy;
     int port;
     String url;
-    DefaultClientConnector client;
+    ClientConnector client;
 
     @Before
     void setUp() {
@@ -25,17 +25,17 @@ class ConnectionReuseTest {
         def endpoint = this.deproxy.addEndpoint(this.port);
 
         def socket = (endpoint.serverConnector as SocketServerConnector).createRawConnection()
-        client = new DefaultClientConnector(new BareClientConnector(socket))
+        client = new BareClientConnector(socket)
 
     }
 
     @Test
     void testServerSideConnectionReuse() {
 
-        def mc1 = deproxy.makeRequest(url: url, clientConnector: client)
+        def mc1 = deproxy.makeRequest(url: url, clientConnector: client, headers: ['Content-length': '0'])
         assertEquals(1, mc1.handlings.size())
 
-        def mc2 = deproxy.makeRequest(url: url, clientConnector: client)
+        def mc2 = deproxy.makeRequest(url: url, clientConnector: client, headers: ['Content-length': '0'])
         assertEquals(1, mc2.handlings.size())
 
         assertEquals(mc1.handlings[0].connection, mc2.handlings[0].connection)

--- a/src/test/groovy/com/rackspace/deproxy/DefaultClientConnectorTest.groovy
+++ b/src/test/groovy/com/rackspace/deproxy/DefaultClientConnectorTest.groovy
@@ -6,21 +6,16 @@ import spock.lang.Unroll
 
 class DefaultClientConnectorTest extends Specification {
 
-    Socket client
-    Socket server
-
     void testConstructorWithSocketParameter() {
 
-        given: "a client socket and a server socket"
-        (client, server) = LocalSocketPair.createLocalSocketPair()
-
-        client.soTimeout = 100 // in milliseconds
-        server.soTimeout = 2000
-
-        and: "a DefaultClientConnector using the provided client socket"
-        DefaultClientConnector clientConnector =
-                new DefaultClientConnector(
-                        new BareClientConnector(client))
+        given: "a DefaultClientConnector using a dummy nextConnector"
+        Request capturedRequest = null
+        def clientConnector =
+                new DefaultClientConnector([
+                        'sendRequest': { request, https, host, port, params ->
+                            capturedRequest = request;
+                            return new Response(200)
+                        }] as ClientConnector)
 
         and: "a simple request"
         Request request = new Request("GET", "/", ['Content-Length': "0"])
@@ -30,41 +25,29 @@ class DefaultClientConnectorTest extends Specification {
 
 
         when: "we send the request through the connector"
-        try {
-
-            Response response = clientConnector.sendRequest(request, false, "localhost", server.getLocalPort(), params)
-
-        } catch (SocketTimeoutException ignored) {
-            // read times out, as expected
-        }
-
-        and: "read the request that the connector sent from the server-side socket"
-        String requestLine = LineReader.readLine(server.inputStream)
-        HeaderCollection headers = HeaderCollection.fromStream(server.inputStream)
-        String body = BodyReader.readBody(server.inputStream, headers)
-
+        Response response = clientConnector.sendRequest(request, false, "localhost", 80, params)
 
         then: "it formats the request correctly and only has the header we specified"
-        requestLine == "GET / HTTP/1.1"
-        headers.size() == 1
-        headers.contains("Content-Length")
-        headers["Content-Length"] == "0"
-        body == "" || body == null
+        capturedRequest.method == 'GET'
+        capturedRequest.path == '/'
+        capturedRequest.headers.size() == 1
+        capturedRequest.headers.contains("Content-Length")
+        capturedRequest.headers["Content-Length"] == "0"
+        capturedRequest.body == "" || capturedRequest.body == null
+        response.code == "200"
     }
 
     @Unroll("when we call sendRequest with https=#https, #host, and #port, we should get Host: #expectedValue")
     void testHostHeader() {
 
-        given: "a client socket and a server socket"
-        (client, server) = LocalSocketPair.createLocalSocketPair()
-
-        client.soTimeout = 100 // in milliseconds
-        server.soTimeout = 2000
-
-        and: "a DefaultClientConnector using the provided client socket"
-        DefaultClientConnector clientConnector =
-                new DefaultClientConnector(
-                        new BareClientConnector(client))
+        given: "a DefaultClientConnector using a dummy nextConnector"
+        Request capturedRequest = null
+        def clientConnector =
+                new DefaultClientConnector([
+                        'sendRequest': { request, https, host, port, params ->
+                            capturedRequest = request;
+                            return new Response(200)
+                        }] as ClientConnector)
 
         and: "a simple request and basic request params"
         Request request = new Request("GET", "/")
@@ -73,32 +56,16 @@ class DefaultClientConnectorTest extends Specification {
 
 
         when: "we send the request through the connector"
-        try {
-
-            // we're explicitly setting the https, host, and port parameters.
-            // the connector was created with a client socket, however. it
-            // will use the socket instead of trying to open a new connection,
-            // and just use the parameters for the Host header.
-            Response response = clientConnector.sendRequest(request, https, host, port, params)
-
-        } catch (SocketTimeoutException ignored) {
-
-            // we're expecting the connector to send the request, and then
-            // wait for a server response. since there is no server in this
-            // case, it will timeout while waiting. then we just read the
-            // request from the server side of the socket.
-        }
-
-        and: "read the request that the connector sent from the server-side socket"
-        String requestLine = LineReader.readLine(server.inputStream)
-        HeaderCollection headers = HeaderCollection.fromStream(server.inputStream)
-
-
+        Response response = clientConnector.sendRequest(request, https, host, port, params)
 
         then: "it formats the request correctly and has a Host header with the right value"
-        requestLine == "GET / HTTP/1.1"
-        headers.contains("Host")
-        headers["Host"] == expectedValue
+        capturedRequest.method == 'GET'
+        capturedRequest.path == '/'
+        capturedRequest.headers.contains("Host")
+        capturedRequest.headers["Host"] == expectedValue
+        response.code == "200"
+
+
 
         where:
         host          | port  | https | expectedValue
@@ -120,14 +87,5 @@ class DefaultClientConnectorTest extends Specification {
         "12.34.56.78" | 443   | false | "12.34.56.78:443"
         "12.34.56.78" | 12345 | true  | "12.34.56.78:12345"
         "12.34.56.78" | 12345 | false | "12.34.56.78:12345"
-    }
-
-    def cleanup() {
-        if (client) {
-            client.close()
-        }
-        if (server) {
-            server.close()
-        }
     }
 }

--- a/src/test/groovy/com/rackspace/deproxy/DefaultClientConnectorTest.groovy
+++ b/src/test/groovy/com/rackspace/deproxy/DefaultClientConnectorTest.groovy
@@ -18,21 +18,26 @@ class DefaultClientConnectorTest extends Specification {
                         }] as ClientConnector)
 
         and: "a simple request"
-        Request request = new Request("GET", "/", ['Content-Length': "0"])
+        Request request = new Request("GET", "/")
 
-        and: "request params that don't involve adding default headers"
-        RequestParams params = [sendDefaultRequestHeaders : false] as RequestParams
 
 
         when: "we send the request through the connector"
+        RequestParams params = new RequestParams()
         Response response = clientConnector.sendRequest(request, false, "localhost", 80, params)
 
-        then: "it formats the request correctly and only has the header we specified"
+        then: "it formats the request correctly and includes the standard default request parameters"
         capturedRequest.method == 'GET'
         capturedRequest.path == '/'
-        capturedRequest.headers.size() == 1
-        capturedRequest.headers.contains("Content-Length")
-        capturedRequest.headers["Content-Length"] == "0"
+        capturedRequest.headers.size() == 4
+        capturedRequest.headers.contains("Host")
+        capturedRequest.headers["Host"] == "localhost"
+        capturedRequest.headers.contains("Accept")
+        capturedRequest.headers["Accept"] == "*/*"
+        capturedRequest.headers.contains("Accept-Encoding")
+        capturedRequest.headers["Accept-Encoding"] == "identity, gzip, compress, deflate, *;q=0"
+        capturedRequest.headers.contains("User-Agent")
+        capturedRequest.headers["User-Agent"] == Deproxy.VERSION_STRING
         capturedRequest.body == "" || capturedRequest.body == null
         response.code == "200"
     }
@@ -51,11 +56,11 @@ class DefaultClientConnectorTest extends Specification {
 
         and: "a simple request and basic request params"
         Request request = new Request("GET", "/")
-        RequestParams params = [sendDefaultRequestHeaders : true] as RequestParams
 
 
 
         when: "we send the request through the connector"
+        def params = new RequestParams()
         Response response = clientConnector.sendRequest(request, https, host, port, params)
 
         then: "it formats the request correctly and has a Host header with the right value"

--- a/src/test/groovy/com/rackspace/deproxy/DefaultClientConnectorTest.groovy
+++ b/src/test/groovy/com/rackspace/deproxy/DefaultClientConnectorTest.groovy
@@ -18,7 +18,9 @@ class DefaultClientConnectorTest extends Specification {
         server.soTimeout = 2000
 
         and: "a DefaultClientConnector using the provided client socket"
-        DefaultClientConnector clientConnector = new DefaultClientConnector(client)
+        DefaultClientConnector clientConnector =
+                new DefaultClientConnector(
+                        new BareClientConnector(client))
 
         and: "a simple request"
         Request request = new Request("GET", "/", ['Content-Length': "0"])
@@ -60,7 +62,9 @@ class DefaultClientConnectorTest extends Specification {
         server.soTimeout = 2000
 
         and: "a DefaultClientConnector using the provided client socket"
-        DefaultClientConnector clientConnector = new DefaultClientConnector(client)
+        DefaultClientConnector clientConnector =
+                new DefaultClientConnector(
+                        new BareClientConnector(client))
 
         and: "a simple request and basic request params"
         Request request = new Request("GET", "/")

--- a/src/test/groovy/com/rackspace/deproxy/DefaultClientConnectorTest.groovy
+++ b/src/test/groovy/com/rackspace/deproxy/DefaultClientConnectorTest.groovy
@@ -6,7 +6,7 @@ import spock.lang.Unroll
 
 class DefaultClientConnectorTest extends Specification {
 
-    void testConstructorWithSocketParameter() {
+    void "when we call sendRequest, we should get the standard default request headers"() {
 
         given: "a DefaultClientConnector using a dummy nextConnector"
         Request capturedRequest = null
@@ -42,8 +42,8 @@ class DefaultClientConnectorTest extends Specification {
         response.code == "200"
     }
 
-    @Unroll("when we call sendRequest with https=#https, #host, and #port, we should get Host: #expectedValue")
-    void testHostHeader() {
+    @Unroll
+    void "when we call sendRequest with https=#https, #host, and #port, we should get Host: #expectedValue"() {
 
         given: "a DefaultClientConnector using a dummy nextConnector"
         Request capturedRequest = null


### PR DESCRIPTION
This PR separates the `DefaultClientConnector` from the `BareClientConnector`, so that the former does not extend the other. Instead, `DefaultClientConnector` is given a `nextConnector` property that allows us to specify a given `BareClientConnector` to send the request to after the default request headers have been added.

It also removes the `sendDefaultRequestHeaders` property from the `RequestParams` class. If a user wants to add default headers to a request, they can use the `DefaultClientConnector`; if they don't want to add those headers, they can just use `BareClientConnector` instead.

This means that `ClientConnector`s can best be viewed as processing stages or filters that act on a request before it gets sent to the target host (and act on the response in the same manner as well). Moreover, we can easily construct new `ClientConnector`s for special purposes. For example, see the changes to `DefaultClientConnectorTest` that create a connector from a map that captures the request to make assertions: 
https://github.com/izrik/deproxy/compare/separate-client-connectors?expand=1#diff-08c44578b070b3b05be97b9175a0614bR15

This will make the tests a little less flaky, because we can test `DefaultClientConnector`'s functionality without having to create a socket pair.