### PR TITLE
Don't count docs in the language stats.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+docs/* linguist-vendored
+


### PR DESCRIPTION
Minor cosmetic annoyance: Github's language stats on the front page of the repo are including python/css/etc files from the docs/ folder. Adding this git attribute will make the stats only count the `groovy` and `java` source code.